### PR TITLE
add data type to perform continung working on the file type task

### DIFF
--- a/src/import-script/res/data_type.py
+++ b/src/import-script/res/data_type.py
@@ -1,0 +1,12 @@
+data_types = {
+    'FileName': {"type": "text"},
+    'FileSize': {"type": "integer"},
+    'MIMEType': {"type": "text","fielddata": True},
+    #TODO: Please try to make this work
+    # 'FileInodeChangeDate': {
+    #     "type": "date",
+    #     "format": "yyyy-MM-dd HH:mm:ss||yyyy-MM-dd||epoch_millis"
+    # },
+    'FileInodeChangeDate': {"type": "text"},
+    'SourceFile': {"type": "text"}
+}


### PR DESCRIPTION
During some refactoring, this feature [Statistics: Filetypes](https://github.com/amosproj/amos2023ss02-open-search-meta-data-hub/issues/33)  stopped working. Please try to fix it as soon as possible because we need to include it in the live demo today.