### PR TITLE
Outcommented the Files-Types-Part

### DIFF
--- a/src/application/res/app.py
+++ b/src/application/res/app.py
@@ -124,10 +124,10 @@ def search():
 def advanced_search_v2():
     return render_template('index1.html')
 
-@app.route('/files_type_chart')
-def files_type_chart():
-    labels, values, colors = files_type.get_files_type()
-    return render_template('doughnut_chart.html', max=17000, set=zip(values, labels, colors))
+#@app.route('/files_type_chart')
+#def files_type_chart():
+#    labels, values, colors = files_type.get_files_type()
+#    return render_template('doughnut_chart.html', max=17000, set=zip(values, labels, colors))
 
 
 @app.route('/visualizations')

--- a/src/application/res/templates/base.html
+++ b/src/application/res/templates/base.html
@@ -33,12 +33,7 @@
             <li class="nav-item active">
                 <a class="nav-link" href="{{ url_for('search')}}">Search</a>
             </li>
-            <li class="nav-item active">
-                <a class="nav-link" href="{{ url_for('files_type_chart')}}"
-                >Files-type</a
-                >
-            </li>
-              <li class="nav-item active">
+        <li class="nav-item active">
                 <a class="nav-link" href="{{ url_for('visualizations')}}">Visualizations</a>
             </li>
             <li class="nav-item active">


### PR DESCRIPTION
It's currently not working and the code in files_type.py is fully outcommented.

So I want to suggest to add this to todays release, so that we have a stable website for release.

In my opinion, we can also delete those files, which are not needed anymore. We should discuss, we need this Files-Type-Section anymore, because you can probably configure this by yourself in the OS-Dashboard. But this shouldn't be a discussion in this pull request, because I just want this to be a hotfix for a stable release.