### PR TITLE
file_types-Option in configfile

### DIFF
--- a/src/application/res/backend/configuration.py
+++ b/src/application/res/backend/configuration.py
@@ -19,6 +19,7 @@ def get_config_values():
         'selected_tags': "FileName;FileSize;FileType;SourceFile",
         'only_selected_tags': False,
         'only_new_data': True,
+        'file_types': "",
     }
 
     # Retrieve values from the config file, with fallback to default values
@@ -36,6 +37,9 @@ def get_config_values():
             options[key] = config.getboolean('General', key, fallback=value)
         elif key == "only_selected_tags":
             options[key] = config.getboolean('General', key, fallback=value)
+        elif key == "file_types":
+            tmp = config.get('General',key,fallback=value)
+            options[key] = tmp.split(";")
         else:
             options[key] = config.get('General', key, fallback=value)
 

--- a/src/application/res/config.ini
+++ b/src/application/res/config.ini
@@ -6,4 +6,4 @@ limit=100
 selected_tags=FileName;FileSize;FileType
 only_selected_tags=False
 only_new_data=False
-
+file_types=XML;JPG

--- a/src/application/res/config.ini
+++ b/src/application/res/config.ini
@@ -6,4 +6,4 @@ limit=100
 selected_tags=FileName;FileSize;FileType
 only_selected_tags=False
 only_new_data=False
-file_types=XML;JPG
+file_types=XML;JPEG

--- a/src/application/res/import-script/import_pipeline.py
+++ b/src/application/res/import-script/import_pipeline.py
@@ -271,12 +271,14 @@ def execute_pipeline(import_control: ImportControl):
         mdh_tags = extract_metadata_tags_from_mdh(mdh_manager=mdh_manager)
         metadata_tags = modify_metadata_tags(mdh_tags=mdh_tags)  # modify the datatypes so they fit in OpenSearch
 
-    file_types = ["XML","JPEG"] #TODO
+    file_types = ["XML","JPEG", "TXT"] #TODO
+    limit = 1500 #TODO
+    limit = int(limit / len(file_types))
 
     for file_type in file_types:
 
         # extract the data from the mdh
-        mdh_data, files_amount = extract_data_from_mdh(mdh_manager=mdh_manager, limit=limit, latest_timestamp=latest_timestamp, selected_tags=selected_tags)
+        mdh_data, files_amount = extract_data_from_mdh(mdh_manager=mdh_manager, limit=limit, latest_timestamp=latest_timestamp, selected_tags=selected_tags, file_type=file_type)
 
         # get the amount of files that exist in the mdh core
         files_in_mdh = mdh_manager.get_total_files_count()

--- a/src/application/res/import-script/import_pipeline.py
+++ b/src/application/res/import-script/import_pipeline.py
@@ -272,7 +272,6 @@ def execute_pipeline(import_control: ImportControl):
         metadata_tags = modify_metadata_tags(mdh_tags=mdh_tags)  # modify the datatypes so they fit in OpenSearch
 
     file_types = ["XML","JPEG", "TXT"] #TODO
-    limit = 1500 #TODO
     limit = int(limit / len(file_types))
 
     for file_type in file_types:

--- a/src/application/res/import-script/import_pipeline.py
+++ b/src/application/res/import-script/import_pipeline.py
@@ -47,7 +47,7 @@ def extract_metadata_tags_from_mdh(mdh_manager: MetaDataHubManager, amount_of_ta
 
 
 def extract_data_from_mdh(mdh_manager: MetaDataHubManager, latest_timestamp: str = False, limit: int = False,
-                          offset: int = False, selected_tags: list = None) -> tuple[list[dict], int]:
+        offset: int = False, selected_tags: list = None, file_type: str = False) -> tuple[list[dict], int]:
     """
     Extract data from the MetaDataHub.
 
@@ -59,7 +59,7 @@ def extract_data_from_mdh(mdh_manager: MetaDataHubManager, latest_timestamp: str
     """
 
     # Download data from the MetaDataHub
-    mdh_manager.download_data(timestamp=latest_timestamp, limit=limit, selected_tags=selected_tags)
+    mdh_manager.download_data(timestamp=latest_timestamp, limit=limit, selected_tags=selected_tags, file_type=file_type)
 
     # Get the data, and the number of downloaded files
     mdh_data = mdh_manager.get_data()
@@ -271,35 +271,39 @@ def execute_pipeline(import_control: ImportControl):
         mdh_tags = extract_metadata_tags_from_mdh(mdh_manager=mdh_manager)
         metadata_tags = modify_metadata_tags(mdh_tags=mdh_tags)  # modify the datatypes so they fit in OpenSearch
 
-    # extract the data from the mdh
-    mdh_data, files_amount = extract_data_from_mdh(mdh_manager=mdh_manager, limit=limit, latest_timestamp=latest_timestamp, selected_tags=selected_tags)
+    file_types = ["XML","JPEG"] #TODO
 
-    # get the amount of files that exist in the mdh core
-    files_in_mdh = mdh_manager.get_total_files_count()
+    for file_type in file_types:
 
-    # create a new import in the 'import.dictionary' file (monitoring purposes)
-    import_control.create_import(files_in_os=files_in_os, files_in_mdh=files_in_mdh)
+        # extract the data from the mdh
+        mdh_data, files_amount = extract_data_from_mdh(mdh_manager=mdh_manager, limit=limit, latest_timestamp=latest_timestamp, selected_tags=selected_tags)
 
-    # modify the data so it can be easily stored in OpenSearch
-    data = modify_data(mdh_data=mdh_data, metadata_tags=metadata_tags,
-                       current_time=current_time)
+        # get the amount of files that exist in the mdh core
+        files_in_mdh = mdh_manager.get_total_files_count()
 
-    # Loading the data into OpenSearch
-    failed_imports = upload_data(index_name=index_name, os_manager=os_manager, metadata_tags=metadata_tags,
-                                 data=data,
-                                 files_amount=files_amount)
+        # create a new import in the 'import.dictionary' file (monitoring purposes)
+        import_control.create_import(files_in_os=files_in_os, files_in_mdh=files_in_mdh)
 
-    # wait for two seconds to avoid synchronization problems
-    time.sleep(2)
+        # modify the data so it can be easily stored in OpenSearch
+        data = modify_data(mdh_data=mdh_data, metadata_tags=metadata_tags,
+                           current_time=current_time)
 
-    # handle the failed imports
-    handle_failed_imports(os_manager, index_name, failed_imports)
+        # Loading the data into OpenSearch
+        failed_imports = upload_data(index_name=index_name, os_manager=os_manager, metadata_tags=metadata_tags,
+                                     data=data,
+                                     files_amount=files_amount)
 
-    # files in os after import
-    imported_files = os_manager.count_files(index_name=index_name) - files_in_os
+        # wait for two seconds to avoid synchronization problems
+        time.sleep(2)
 
-    # update the import in the 'import.dictionary' file
-    import_control.update_import(imported_files=imported_files)
+        # handle the failed imports
+        handle_failed_imports(os_manager, index_name, failed_imports)
+
+        # files in os after import
+        imported_files = os_manager.count_files(index_name=index_name) - files_in_os
+
+        # update the import in the 'import.dictionary' file
+        import_control.update_import(imported_files=imported_files)
 
     # print the import results
     print_import_pipeline_results(start_time=start_time, imported_files=imported_files)

--- a/src/application/res/import-script/import_pipeline.py
+++ b/src/application/res/import-script/import_pipeline.py
@@ -244,6 +244,8 @@ def execute_pipeline(import_control: ImportControl):
     else:
         selected_tags = []
 
+    file_types = options['file_types']
+
     # get current time
     current_time = datetime.now().strftime("%Y-%m-%dT%H:%M:%S")
 
@@ -271,7 +273,7 @@ def execute_pipeline(import_control: ImportControl):
         mdh_tags = extract_metadata_tags_from_mdh(mdh_manager=mdh_manager)
         metadata_tags = modify_metadata_tags(mdh_tags=mdh_tags)  # modify the datatypes so they fit in OpenSearch
 
-    file_types = ["XML","JPEG", "TXT"] #TODO
+    #file_types = ["XML","JPEG", "TXT"] #TODO
     limit = int(limit / len(file_types))
 
     for file_type in file_types:

--- a/src/application/res/import-script/mdh_api.py
+++ b/src/application/res/import-script/mdh_api.py
@@ -83,8 +83,7 @@ class MetaDataHubManager:
         self._write_file(self.format_query(gql_query.generate_tag_query()))
         return gql_query
 
-    def _generate_data_query(self, timestamp: str = False, filters: list = None, limit: int = False, offset: int = False, selected_tags: list = None):
-
+    def _generate_data_query(self, timestamp: str = False, filters: list = None, limit: int = False, offset: int = False, selected_tags: list = None, file_type: str = False):
         filter_functions = []
         if timestamp:
             f = FilterFunction(tag="MdHTimestamp", value=timestamp, operation="GREATER", data_type="TS")
@@ -93,6 +92,10 @@ class MetaDataHubManager:
         if selected_tags:
             if "SourceFile" not in selected_tags:
                 selected_tags.append("SourceFile")
+
+        if file_type: 
+            t = FilterFunction(tag="FileType", value=file_type, operation="EQUAL", data_type="STR")
+            filter_functions.append(t)
 
         sort_functions = [
             SortFunction(tag="MdHTimestamp", operation="ASC"),
@@ -122,9 +125,9 @@ class MetaDataHubManager:
         for core in mdh.core.main.get():
             self.metadata_tags = mdh.core.main.execute(core, self._request_path_file)
 
-    def download_data(self, timestamp: str = False, limit: int = False, offset: int = False, selected_tags: list = None):
+    def download_data(self, timestamp: str = False, limit: int = False, offset: int = False, selected_tags: list = None, file_type: str = False):
         """ download the data from a request and store it """
-        self._generate_data_query(timestamp=timestamp, limit=limit, offset=offset, selected_tags=selected_tags)
+        self._generate_data_query(timestamp=timestamp, limit=limit, offset=offset, selected_tags=selected_tags, file_type)
         for core in mdh.core.main.get():
             self.data = mdh.core.main.execute(core, self._request_path_file)
 

--- a/src/application/res/import-script/mdh_api.py
+++ b/src/application/res/import-script/mdh_api.py
@@ -127,7 +127,7 @@ class MetaDataHubManager:
 
     def download_data(self, timestamp: str = False, limit: int = False, offset: int = False, selected_tags: list = None, file_type: str = False):
         """ download the data from a request and store it """
-        self._generate_data_query(timestamp=timestamp, limit=limit, offset=offset, selected_tags=selected_tags, file_type)
+        self._generate_data_query(timestamp=timestamp, limit=limit, offset=offset, selected_tags=selected_tags, file_type=file_type)
         for core in mdh.core.main.get():
             self.data = mdh.core.main.execute(core, self._request_path_file)
 


### PR DESCRIPTION
We added a file_types-Option to the configfile. You can add them with `file_types=XML;JPEG`. We also defined a default value (import data from possibly all file_types).

_Note, that we requested to merge it into `fix_import_pipeline`. It should be possible to first merge `fix_import_pipeline` into main, so that we include the much more important features first. Merging this branch into `main` after it shouldn't be a big problem thanks to rebasing, if needed._