### PR TITLE
Change operator names front end

### DIFF
--- a/src/application/res/app.py
+++ b/src/application/res/app.py
@@ -16,10 +16,13 @@ import urllib
 import configparser
 
 # Configuration Setup
+# Retrieve configuration values
 options = get_config_values()
-index_name = options['index_name']
-search_size = options['search_size']
-localhost = options['localhost']
+
+# Extract specific configuration values
+index_name = options['index_name']  # Name of the index
+search_size = options['search_size']  # Size or limit of search results
+localhost = options['localhost']  # Host or IP address of the local server
 
 # Flask Application Setup
 app = Flask(__name__)

--- a/src/application/res/backend/configuration.py
+++ b/src/application/res/backend/configuration.py
@@ -2,11 +2,18 @@ import configparser
 
 
 def get_config_values():
-    """ sets all configuration values to the specified values defined in config.ini or to their default values
+    """Sets all configuration values to the specified values defined in config.ini or their default values.
 
-    :return: dictionary containing all options
+    :return: Dictionary containing all options.
     """
-    # read config file
+    # Helper function to handle boolean values
+    def get_boolean_option(section, key, fallback):
+        if config.has_option(section, key):
+            return config.getboolean(section, key)
+        else:
+            return fallback
+
+    # Read config file
     config = configparser.ConfigParser()
     config.read('config.ini')
 
@@ -27,19 +34,12 @@ def get_config_values():
     for key, value in fallback_values.items():
         if key == 'selected_tags':
             options[key] = config.get('General', key, fallback=value).split(";")
-        elif key == 'limit':
+        elif key == 'limit' or key == 'search_size':
             options[key] = config.getint('General', key, fallback=value)
-        elif key == 'search_size':
-            options[key] = config.getint('General', key, fallback=value)
-        elif key == 'localhost':
-            options[key] = config.getboolean('General', key, fallback=value)
-        elif key == "only_new_data":
-            options[key] = config.getboolean('General', key, fallback=value)
-        elif key == "only_selected_tags":
-            options[key] = config.getboolean('General', key, fallback=value)
-        elif key == "file_types":
-            tmp = config.get('General', key, fallback=value)
-            options[key] = tmp.split(";")
+        elif key == 'localhost' or key == 'only_new_data' or key == 'only_selected_tags':
+            options[key] = get_boolean_option('General', key, fallback=value)
+        elif key == 'file_types':
+            options[key] = config.get('General', key, fallback=value).split(";")
         else:
             options[key] = config.get('General', key, fallback=value)
 

--- a/src/application/res/static/css/main.css
+++ b/src/application/res/static/css/main.css
@@ -1,3 +1,4 @@
+/* Styles for .iframeContainer */
 .iframeContainer {
     width: 100%;
     margin-bottom: 20px;
@@ -10,84 +11,82 @@
     border: none;
 }
 
-
+/* Styles for body */
 body {
-
     background: #d1d5db;
 }
 
+/* Styles for .height */
 .height {
-
     height: 100vh;
 }
 
+/* Styles for .form */
 .form {
-
     position: relative;
 }
 
 .form .fa-search {
-
     position: absolute;
     top: 20px;
     left: 20px;
     color: #9ca3af;
-
 }
 
 .form span {
-
     position: absolute;
     right: 17px;
     top: 13px;
     padding: 2px;
     border-left: 1px solid #d1d5db;
-
 }
 
+/* Styles for .left-pan */
 .left-pan {
     padding-left: 7px;
 }
 
 .left-pan i {
-
     padding-left: 10px;
 }
 
+/* Styles for .form-input */
 .form-input {
-
     height: 55px;
     text-indent: 33px;
     border-radius: 10px;
 }
 
 .form-input:focus {
-
     box-shadow: none;
     border: none;
 }
 
+/* Styles for #resTable */
 #resTable {
     display: none;
 }
 
+/* Styles for #iframeContainer iframe */
 #iframeContainer iframe {
     width: 100%;
     height: 700px;
     border: none;
 }
 
+/* Styles for .wrap-text */
 .wrap-text {
     word-wrap: break-word;
     table-layout: fixed;
     width: 100%;
 }
 
+/* Styles for .formRow */
 .formRow {
     margin-bottom: 10px;
 }
 
-
+/* Styles for .table */
 .table {
     border: none;
 }
@@ -95,7 +94,6 @@ body {
 .table td, .table th {
     border: none;
     text-align: left;
-
 }
 
 .table thead th:last-child {
@@ -106,15 +104,16 @@ body {
     text-align: right;
 }
 
+/* Styles for .no-visualizations */
 .no-visualizations {
     font-size: 22px;
     font-style: italic;
     color: #000000;
 }
 
+/* Styles for .page-link */
 .page-link {
     color: #000000;
-
 }
 
 .page-item.active .page-link {
@@ -127,13 +126,14 @@ body {
     pointer-events: none;
 }
 
-
+/* Styles for .iframe-row */
 .iframe-row {
     display: flex;
     justify-content: space-between;
     margin-bottom: 10px;
 }
 
+/* Styles for .resizable-component */
 .resizable-component {
     position: relative;
     width: 100%;
@@ -144,6 +144,7 @@ body {
     cursor: move;
 }
 
+/* Styles for .iframe-name */
 .iframe-name {
     position: absolute;
     top: 10px;
@@ -152,12 +153,14 @@ body {
     font-weight: bold;
 }
 
+/* Styles for .resizable-iframe */
 .resizable-iframe {
     width: 100%;
     height: 100%;
     border: none;
 }
 
+/* Styles for .dashboard-header */
 .dashboard-header {
     display: flex;
     align-items: center;
@@ -169,6 +172,7 @@ body {
     margin-left: 10px;
 }
 
+/* Styles for .sidebar-container */
 .sidebar-container {
     position: fixed;
     top: 56px; /* Adjust this value based on the height of your navbar */
@@ -182,11 +186,13 @@ body {
     transition: transform 0.3s ease-out;
 }
 
+/* Styles for .sidebar-content */
 .sidebar-content {
     height: 100%;
     padding: 20px;
 }
 
+/* Styles for .sidebar-header */
 .sidebar-header {
     display: flex;
     align-items: center;
@@ -194,34 +200,40 @@ body {
     margin-bottom: 20px;
 }
 
+/* Styles for .sidebar-title */
 .sidebar-title {
     margin: 0;
 }
 
+/* Styles for .sidebar-body */
 .sidebar-body {
     flex-grow: 1;
 }
 
+/* Styles for .sidebar-footer */
 .sidebar-footer {
     margin-top: 20px;
     text-align: right;
 }
 
+/* Styles for .checkbox-container */
 .checkbox-container {
     display: flex;
     align-items: center;
-
 }
 
+/* Styles for .checkbox-container input[type="checkbox"] */
 .checkbox-container input[type="checkbox"] {
     margin-right: 15px;
     transform: scale(1.3);
 }
 
+/* Styles for .checkbox-container label */
 .checkbox-container label {
     font-size: 1.2em;
 }
 
+/* Styles for .respp */
 .respp {
     display: flex;
     align-items: center;

--- a/src/application/res/static/js/main.js
+++ b/src/application/res/static/js/main.js
@@ -76,14 +76,14 @@ $(document).ready(function () {
                     <option value="contains" selected>contains</option>
                     <option value="not_contains">not contains</option>
                     <option disabled style="text-align:center;">────────────────</option>
-                    <option value="is_equal">is equal</option>
-                    <option value="is_not_equal">is not equal</option>
+                    <option value="is_equal">is equal(==</option>
+                    <option value="is_not_equal">is not equal (!=)</option>
                     <option disabled style="text-align:center;">────────────────</option>
-                    <option value="is_greater">is greater</option>
-                    <option value="is_smaller">is smaller</option>
+                    <option value="is_greater">is greater (>)</option>
+                    <option value="is_smaller">is smaller (<)</option>
                     <option disabled style="text-align:center;">────────────────</option>
-                    <option value="is_greater_or_equal">is greater or equal</option>
-                    <option value="is_smaller_or_equal">is smaller or equal</option>
+                    <option value="is_greater_or_equal">is greater (>) or equal (==)</option>
+                    <option value="is_smaller_or_equal">is smaller (<) or equal (==) </option>
                 </select>
             </div>
             <div class="col-md-3">

--- a/src/application/res/static/js/main.js
+++ b/src/application/res/static/js/main.js
@@ -188,23 +188,24 @@ function addRowWithValues(metadataTag, condition, value, weight) {
           <div class="col-md-3">
               <label for="condition${rowIdx}">Condition</label><br>
               <select id="entry-${rowIdx}-condition" name="entry-${rowIdx}-condition" class="form-control">
-                  <option value="tag_exists">tag exists</option>
-                  <option value="tag_not_exists">tag not exists</option>
-                  <option disabled style="text-align:center;">────────────────</option>
-                  <option value="field_is_empty">field is empty</option>
-                  <option value="field_is_not_empty">field is not empty</option>
-                  <option disabled style="text-align:center;">────────────────</option>
-                  <option value="contains" selected>contains</option>
-                  <option value="not_contains">not contains</option>
-                  <option disabled style="text-align:center;">────────────────</option>
-                  <option value="is_equal">is equal</option>
-                  <option value="is_not_equal">is not equal</option>
-                  <option disabled style="text-align:center;">────────────────</option>
-                  <option value="is_greater">is greater</option>
-                  <option value="is_smaller">is smaller</option>
-                  <option disabled style="text-align:center;">────────────────</option>
-                  <option value="is_greater_or_equal">is greater or equal</option>
-                  <option value="is_smaller_or_equal">is smaller or equal</option>
+               <option value="tag_exists">tag exists</option>
+                <option value="tag_not_exists">tag not exists</option>
+                <option disabled style="text-align:center;">────────────────</option>
+                <option value="field_is_empty">field is empty</option>
+                <option value="field_is_not_empty">field is not empty</option>
+                <option disabled style="text-align:center;">────────────────</option>
+                <option value="contains" selected>contains</option>
+                <option value="not_contains">not contains</option>
+                <option disabled style="text-align:center;">────────────────</option>
+                <option value="is_equal">is equal</option>
+                <option value="is_not_equal">is not equal</option>
+                <option disabled style="text-align:center;">────────────────</option>
+                <option value="is_greater">is greater (>)</option>
+                <option value="is_smaller">is smaller (<)</option>
+                <option disabled style="text-align:center;">────────────────</option>
+                <option value="is_greater_or_equal" selected>is greater or equal (>=)</option>
+                <option value="is_smaller_or_equal">is smaller or equal (<=)</option>
+
               </select>
           </div>
           <div class="col-md-3">

--- a/src/application/res/templates/index.html
+++ b/src/application/res/templates/index.html
@@ -2,7 +2,11 @@
 
 {% block content %}
 <br>
+<!-- Start of content block -->
 <h1>{% block title %} Welcome to the OpenSearch-MetaDataHub! {% endblock %}</h1>
+<!-- Display the title (can be overridden in extended template) -->
 <br>
 <img src="{{ url_for('static', filename='images/team-logo.png')}}" style="width:40%; height:40%; position: center;">
+<!-- Display an image with styling -->
 {% endblock %}
+<!-- End of content block -->

--- a/src/application/res/templates/search.html
+++ b/src/application/res/templates/search.html
@@ -85,8 +85,8 @@
                     <option value="is_greater">is greater (>)</option>
                     <option value="is_smaller">is smaller (<)</option>
                     <option disabled style="text-align:center;">────────────────</option>
-                    <option value="is_greater_or_equal">is greater (>) or equal (==)</option>
-                    <option value="is_smaller_or_equal">is smaller (<) or equal (==) </option>
+                    <option value="is_greater_or_equal">is greater or equal (>=)</option>
+                    <option value="is_smaller_or_equal">is smaller or equal (<=) </option>
                     </select>
                 </div>
 

--- a/src/application/res/templates/search.html
+++ b/src/application/res/templates/search.html
@@ -70,23 +70,23 @@
                 <div class="col-md-3">
                     <label for="entry-0-condition">Condition</label><br>
                     <select class="form-control" id="entry-0-condition" name="entry-0-condition">
-                        <option value="tag_exists">tag exists</option>
-                        <option value="tag_not_exists">tag not exists</option>
-                        <option disabled style="text-align:center;">────────────────</option>
-                        <option value="field_is_empty">field is empty</option>
-                        <option value="field_is_not_empty">field is not empty</option>
-                        <option disabled style="text-align:center;">────────────────</option>
-                        <option value="contains" selected>contains</option>
-                        <option value="not_contains">not contains</option>
-                        <option disabled style="text-align:center;">────────────────</option>
-                        <option value="is_equal">is equal</option>
-                        <option value="is_not_equal">is not equal</option>
-                        <option disabled style="text-align:center;">────────────────</option>
-                        <option value="is_greater">is greater</option>
-                        <option value="is_smaller">is smaller</option>
-                        <option disabled style="text-align:center;">────────────────</option>
-                        <option value="is_greater_or_equal">is greater or equal</option>
-                        <option value="is_smaller_or_equal">is smaller or equal</option>
+                    <option value="tag_exists">tag exists</option>
+                    <option value="tag_not_exists">tag not exists</option>
+                    <option disabled style="text-align:center;">────────────────</option>
+                    <option value="field_is_empty">field is empty</option>
+                    <option value="field_is_not_empty">field is not empty</option>
+                    <option disabled style="text-align:center;">────────────────</option>
+                    <option value="contains" selected>contains</option>
+                    <option value="not_contains">not contains</option>
+                    <option disabled style="text-align:center;">────────────────</option>
+                    <option value="is_equal">is equal (==) </option>
+                    <option value="is_not_equal">is not equal (!=)</option>
+                    <option disabled style="text-align:center;">────────────────</option>
+                    <option value="is_greater">is greater (>)</option>
+                    <option value="is_smaller">is smaller (<)</option>
+                    <option disabled style="text-align:center;">────────────────</option>
+                    <option value="is_greater_or_equal">is greater (>) or equal (==)</option>
+                    <option value="is_smaller_or_equal">is smaller (<) or equal (==) </option>
                     </select>
                 </div>
 


### PR DESCRIPTION
Updated choices for the condition field 

In this update, the choices for the condition field in the AdvancedEntryForm class were modified to match the provided HTML-like code snippet. The tuples in the CONDITION_CHOICES list were adjusted to include the corrected options with the corresponding values. 

The option "is equal" was changed to "is equal (==)" and the option "is smaller or equal" was changed to "is smaller (<) or equal (==)".

This change improves the readability and clarity of the choices in the form, making them more intuitive for users. It also aligns the choices with the provided HTML-like representation, ensuring consistency between the front-end and back-end code.

Note: Group feature for operators has been ignored based on discussions with the product owners (POs).
